### PR TITLE
missing newline after multipart footer

### DIFF
--- a/src/net35/Hammock/Web/WebQuery.cs
+++ b/src/net35/Hammock/Web/WebQuery.cs
@@ -1329,7 +1329,7 @@ namespace Hammock.Web
                 }
             }
 
-            written += Write(write, encoding, requestStream, footer);
+            written += WriteLine(write, encoding, requestStream, footer);
 #if TRACE
             if(write)
             {


### PR DESCRIPTION
after the multi part close-delimiter( boundary + two dashes ) there should be a CRLF/newline.

from https://aspnetwebstack.codeplex.com/workitem/232 : 
"While it is technically allowed not to have the CRLF as part of the boundary all the MIME multipart generators we have tries (notably all the major browsers) do generate it. Adding support for this has a surprising effect on the complexity of the parser and so we prefer not to do it at this time."