### PR TITLE
Fixes Issue #75, System.NullReferenceException in Hammock.RestClient.CompleteWithQuery

### DIFF
--- a/src/net35/Hammock/RestClient.cs
+++ b/src/net35/Hammock/RestClient.cs
@@ -1765,7 +1765,7 @@ namespace Hammock
                 return;
             }
 
-            var wasStreaming = response.Content.Equals(EndStreamingContent);
+            var wasStreaming = (response.Content != null && response.Content.Equals(EndStreamingContent));
 
             result.AsyncState = response;
             result.IsCompleted = true;
@@ -1794,7 +1794,7 @@ namespace Hammock
                 return;
             }
 
-            var wasStreaming = response.Content.Equals(EndStreamingContent);
+            var wasStreaming = (response.Content != null && response.Content.Equals(EndStreamingContent));
 
             result.AsyncState = response;
             result.IsCompleted = true;


### PR DESCRIPTION
Addition of a null check on Content, which was already present in the mobile phone specific code, but which caused null exceptions in the normal code as well, on some responses. (503, etc.) Fixes Issue #75