### PR TITLE
Support for UTF32 characters

### DIFF
--- a/src/net35/Hammock.Tests/OAuth/OAuthToolsTests.cs
+++ b/src/net35/Hammock.Tests/OAuth/OAuthToolsTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -220,10 +220,21 @@ namespace Hammock.Tests.OAuth
         [Test]
         public void Can_strict_url_encode_complex_string()
         {
-            const string expected = "%21%3F%22%3B%3A%3C%3E%5C%5C%7C%60%23%24%25%5E%26%2A%2B-_%7B%7D%5B%5D";
-            const string sequence = @"!?"";:<>\\|`#$%^&*+-_{}[]";
+            const string expected = "123AaBb%21%3F%22%3B%3A%3C%3E%5C%5C%7C%60%23%24%25%5E%26%2A%2B-_%7B%7D%5B%5D%F0%9F%98%83";
+            const string sequence = @"123AaBb!?"";:<>\\|`#$%^&*+-_{}[]😃";
 
             var actual = OAuthTools.UrlEncodeStrict(sequence);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Can_strict_prevent_double_encoding()
+        {
+            const string expected = "123AaBb%21%3F%22%3B%3A%3C%3E%5C%5C%7C%60%23%24%25%5E%26%2A%2B-_%7B%7D%5B%5D%F0%9F%98%83";
+            const string sequence = @"123AaBb!?"";:<>\\|`#$%^&*+-_{}[]😃";
+
+            var actual = OAuthTools.UrlEncodeStrict(sequence);
+            actual = OAuthTools.UrlEncodeStrict(actual);
             Assert.AreEqual(expected, actual);
         }
 
@@ -231,8 +242,8 @@ namespace Hammock.Tests.OAuth
         public void Can_relax_url_encode_complex_string()
         {
             // Doesn't URL encode ! or * in this sequence
-            const string expected = "!%3F%22%3B%3A%3C%3E%5C%5C%7C%60%23%24%25%5E%26*%2B-_%7B%7D%5B%5D";
-            const string sequence = @"!?"";:<>\\|`#$%^&*+-_{}[]";
+            const string expected = "!%3F%22%3B%3A%3C%3E%5C%5C%7C%60%23%24%25%5E%26*%2B-_%7B%7D%5B%5D%F0%9F%98%83";
+            const string sequence = @"!?"";:<>\\|`#$%^&*+-_{}[]😃";
 
             var actual = OAuthTools.UrlEncodeRelaxed(sequence);
             Assert.AreEqual(expected, actual);


### PR DESCRIPTION
Specifically done to support emoji unicode blocks in tweetsharp
http://www.unicode.org/charts/PDF/U1F600.pdf

Previously it would incorrectly split the surrogates:
Before: "Hammock UnitTest: ��"
After: "Hammock UnitTest: 😃"